### PR TITLE
Improve python 2.6 support

### DIFF
--- a/lib/api.py
+++ b/lib/api.py
@@ -17,7 +17,7 @@ class Content(object):
     def __str__(self):
         return self.content
     def __repr__(self):
-        return 'content({}, {})'.format(self.mimetype, len(self.content))
+        return 'content({0}, {1})'.format(self.mimetype, len(self.content))
 
 class API(object):
     """Flask API.
@@ -57,7 +57,7 @@ class API(object):
         if uri is None:
             uri = self.spec['uri']
         if not uri.startswith('/'):
-            raise ValueError('base uri needs to start with slash: {}'.format(uri))
+            raise ValueError('base uri needs to start with slash: {0}'.format(uri))
 
         self.uri = uri
         self.id = id or self.spec['id']
@@ -68,7 +68,7 @@ class API(object):
 
         if not uri.startswith(self.uri):
             if not uri.startswith('/'):
-                raise ValueError('resource uri needs to start with slash: {}'.format(uri))
+                raise ValueError('resource uri needs to start with slash: {0}'.format(uri))
             uri = self.uri + uri
 
         return self.api[uri]
@@ -87,11 +87,11 @@ class API(object):
 
             for method in methods:
                 if method.lower() not in resource['methodsByName']:
-                    raise ValueError('unknown resource method: {} {}'.format(method, resource['uri']))
+                    raise ValueError('unknown resource method: {0} {1}'.format(method, resource['uri']))
 
             return methods
 
-        raise ValueError('requires a {}list/string of methods, or None, not {} {!r}'.format(
+        raise ValueError('requires a {0}list/string of methods, or None, not {1} {2!r}'.format(
             '' if allow_empty else 'non-empty ', type(methods), methods))
 
     def get_method_spec(self, resource, method=None):
@@ -192,8 +192,8 @@ class API(object):
             for k in dir(self) if k not in exclude and not k.startswith('_') and not callable(getattr(self, k)))
 
     def __str__(self):
-        return '{}.{}({}: {}: {} resources)'.format(self.__class__.__module__, self.__class__.__name__.lower(),
+        return '{0}.{1}({2}: {3}: {4} resources)'.format(self.__class__.__module__, self.__class__.__name__.lower(),
             self.id, self.uri, len(self.api))
 
     def __repr__(self):
-        return '{}{}'.format(self, ''.join('\n  {} = {}'.format(k, v) for k, v in self.config.items()))
+        return '{0}{1}'.format(self, ''.join('\n  {0} = {1}'.format(k, v) for k, v in self.config.items()))

--- a/lib/converter.py
+++ b/lib/converter.py
@@ -71,30 +71,30 @@ class Converter(object):
 
         if typename == 'string' and isinstance(value, basestring):
             if 'enum' in spec and value not in spec['enum']:
-                raise ValueError('not one of {!r}: {!r}'.format(spec['enum'], value))
+                raise ValueError('not one of {0!r}: {1!r}'.format(spec['enum'], value))
 
             if 'pattern' in spec:
                 pattern = spec['pattern']
                 if isinstance(pattern, basestring):
                     pattern = spec['pattern'] = re.compile(pattern)
                 if not pattern.search(value):
-                    raise ValueError('does not match regexp {!r}: {!r}'.format(pattern.pattern, value))
+                    raise ValueError('does not match regexp {0!r}: {1!r}'.format(pattern.pattern, value))
 
             if 'minLength' in spec and len(value) < spec['minLength']:
-                raise ValueError('too short: {} < {!r}'.format(len(value), spec['minLength']))
+                raise ValueError('too short: {0} < {1!r}'.format(len(value), spec['minLength']))
 
             if 'maxLength' in spec and len(value) > spec['maxLength']:
-                raise ValueError('too long: {} > {!r}'.format(len(value), spec['maxLength']))
+                raise ValueError('too long: {0} > {1!r}'.format(len(value), spec['maxLength']))
 
         elif typename in ('integer', 'number'):
             if 'minimum' in spec and value < spec['minimum']:
-                raise ValueError('too small: {!r} < {!r}'.format(value, spec['minimum']))
+                raise ValueError('too small: {0!r} < {1!r}'.format(value, spec['minimum']))
 
             if 'maximum' in spec and value > spec['maximum']:
-                raise ValueError('too large: {!r} > {!r}'.format(value, spec['maximum']))
+                raise ValueError('too large: {0!r} > {1!r}'.format(value, spec['maximum']))
 
         return value
 
     def __str__(self):
-        return '{}.{}({})'.format(self.__class__.__module__, self.__class__.__name__.lower(),
+        return '{0}.{1}({2})'.format(self.__class__.__module__, self.__class__.__name__.lower(),
             ', '.join(k.replace('converters_', '') for k in dir(self) if k.startswith('converters_')))

--- a/lib/loader.py
+++ b/lib/loader.py
@@ -21,7 +21,7 @@ class Loader(dataloader.Loader):
             params = spec.get('baseUriParameters', None)
 
         spec['allUriParameters'] = params = dict(
-            (key, param) for key, param in params.items() if '{{{}}}'.format(key) in uri) if params else {}
+            (key, param) for key, param in params.items() if '{{{0}}}'.format(key) in uri) if params else {}
         spec['uri'] = spec['relativeUri'] = uri
 
         for resource in spec['resources']:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ properties = dict(
     name = 'PyRAML',
     version = __version__,
     url = 'https://github.com/salsita/pyraml',
-    download_url = 'https://github.com/salsita/pyraml/tarball/v{}'.format( __version__),
+    download_url = 'https://github.com/salsita/pyraml/tarball/v{0}'.format( __version__),
     description = __doc__.strip().split('\n', 1)[0].strip('.'),
         # First non-empty line of module doc
     long_description = (__doc__.strip() + '\n').split('\n', 1)[1].strip(),


### PR DESCRIPTION
String formatting in python 2.6 does not support using replacement field without name or index. So in Python 2.6 is not possible to use "{}".format(arg), instead of this we should use "{0}".format(arg)
