### PR TITLE
Use `open` rather than `file` for Python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import re
-__src__ = file('lib/__init__.py').read()
+__src__ = open('lib/__init__.py').read()
 __doc__ = re.search('^(["\']{3})(.*?)\\1', __src__, re.M|re.S).group(2).strip()
 __version__ = re.search('^__version__\s*=\s*(["\'])(.*?)\\1\s*$', __src__, re.M).group(2).strip()
 


### PR DESCRIPTION
It does exactly the same thing, but works with Python 3
